### PR TITLE
Empezar, finalizar y cancelar un trabajo

### DIFF
--- a/src/components/post/show.js
+++ b/src/components/post/show.js
@@ -10,6 +10,7 @@ import {
   CREATE_APPLICATION,
   ACCEPT_APPLICANT,
 } from "../../graphql/mutations/applications";
+import { START_JOB, CANCEL_JOB } from "../../graphql/mutations/posts";
 import { Loading } from "../../containers";
 
 export default function PostShowComponent(props) {
@@ -44,6 +45,9 @@ export default function PostShowComponent(props) {
   const stateNames = {
     open: "Disponible",
     closed: "No disponible",
+    finished: "Terminada",
+    cancelled: "Cancelada",
+    initialized: "Iniciada",
   };
 
   const [createApplication] = useMutation(CREATE_APPLICATION, {
@@ -63,6 +67,16 @@ export default function PostShowComponent(props) {
     onError() {
       setShowErrorAlertEmployer(true);
     },
+  });
+
+  const [startJob] = useMutation(START_JOB, {
+    onCompleted() {},
+    onError() {},
+  });
+
+  const [cancelJob] = useMutation(CANCEL_JOB, {
+    onCompleted() {},
+    onError() {},
   });
 
   const { data, loading } = useQuery(GET_USER_APPLICATIONS, {
@@ -111,6 +125,14 @@ export default function PostShowComponent(props) {
   ) : (
     <p className="postShow-applied-text">Ya has postulado a este trabajo</p>
   );
+
+  const handleStart = () => {
+    startJob({ variables: { jobId: id } });
+  };
+
+  const handleCancel = () => {
+    cancelJob({ variables: { jobId: id } });
+  };
   return (
     <>
       <Row>
@@ -118,6 +140,22 @@ export default function PostShowComponent(props) {
           <h1 className="postShow-name">{name}</h1>
           <p>{description.substring(0, 100) + "..."}</p>
           <p>Vacantes: {applicantLimit}</p>
+          {state.name === "open" ? (
+            <div>
+              <Button
+                className="postShow-application-button mx-2"
+                onClick={handleStart}
+              >
+                Iniciar trabajo
+              </Button>
+              <Button
+                className="postShow-application-button mx-2"
+                onClick={handleCancel}
+              >
+                Cancelar trabajo
+              </Button>
+            </div>
+          ) : null}
           {currentUser.role.name === "employee" ? applicationButton : null}
           {showSuccessAlert || showSuccessAlertEmployer ? (
             <Alert

--- a/src/components/post/show.js
+++ b/src/components/post/show.js
@@ -10,7 +10,11 @@ import {
   CREATE_APPLICATION,
   ACCEPT_APPLICANT,
 } from "../../graphql/mutations/applications";
-import { START_JOB, CANCEL_JOB } from "../../graphql/mutations/posts";
+import {
+  START_JOB,
+  CANCEL_JOB,
+  FINISH_JOB,
+} from "../../graphql/mutations/posts";
 import { Loading } from "../../containers";
 
 export default function PostShowComponent(props) {
@@ -79,6 +83,11 @@ export default function PostShowComponent(props) {
     onError() {},
   });
 
+  const [finishJob] = useMutation(FINISH_JOB, {
+    onCompleted() {},
+    onError() {},
+  });
+
   const { data, loading } = useQuery(GET_USER_APPLICATIONS, {
     fetchPolicy: "network-only",
     variables: { id: currentUser.id },
@@ -133,6 +142,10 @@ export default function PostShowComponent(props) {
   const handleCancel = () => {
     cancelJob({ variables: { jobId: id } });
   };
+
+  const handleFinish = () => {
+    finishJob({ variables: { jobId: id } });
+  };
   return (
     <>
       <Row>
@@ -153,6 +166,16 @@ export default function PostShowComponent(props) {
                 onClick={handleCancel}
               >
                 Cancelar trabajo
+              </Button>
+            </div>
+          ) : null}
+          {state.name === "initialized" ? (
+            <div>
+              <Button
+                className="postShow-application-button mx-2"
+                onClick={handleFinish}
+              >
+                Finalizar trabajo
               </Button>
             </div>
           ) : null}

--- a/src/components/post/show.js
+++ b/src/components/post/show.js
@@ -153,7 +153,7 @@ export default function PostShowComponent(props) {
           <h1 className="postShow-name">{name}</h1>
           <p>{description.substring(0, 100) + "..."}</p>
           <p>Vacantes: {applicantLimit}</p>
-          {state.name === "open" ? (
+          {state.name === "open" && currentUser.role.name === "employer" ? (
             <div>
               <Button
                 className="postShow-application-button mx-2"
@@ -169,7 +169,8 @@ export default function PostShowComponent(props) {
               </Button>
             </div>
           ) : null}
-          {state.name === "initialized" ? (
+          {state.name === "initialized" &&
+          currentUser.role.name === "employer" ? (
             <div>
               <Button
                 className="postShow-application-button mx-2"

--- a/src/graphql/mutations/posts.js
+++ b/src/graphql/mutations/posts.js
@@ -39,3 +39,9 @@ export const CANCEL_JOB = gql`
     cancelJob(jobId: $jobId)
   }
 `;
+
+export const FINISH_JOB = gql`
+  mutation finishJob($jobId: Int!) {
+    finishJob(jobId: $jobId)
+  }
+`;

--- a/src/graphql/mutations/posts.js
+++ b/src/graphql/mutations/posts.js
@@ -30,16 +30,12 @@ export const CREATE_POST = gql`
 
 export const START_JOB = gql`
   mutation initializeJob($jobId: Int!) {
-    initializeJob(jobId: $jobId) {
-      id
-    }
+    initializeJob(jobId: $jobId)
   }
 `;
 
 export const CANCEL_JOB = gql`
   mutation cancelJob($jobId: Int!) {
-    cancelJob(jobId: $jobId) {
-      id
-    }
+    cancelJob(jobId: $jobId)
   }
 `;

--- a/src/graphql/mutations/posts.js
+++ b/src/graphql/mutations/posts.js
@@ -27,3 +27,19 @@ export const CREATE_POST = gql`
     }
   }
 `;
+
+export const START_JOB = gql`
+  mutation initializeJob($jobId: Int!) {
+    initializeJob(jobId: $jobId) {
+      id
+    }
+  }
+`;
+
+export const CANCEL_JOB = gql`
+  mutation cancelJob($jobId: Int!) {
+    cancelJob(jobId: $jobId) {
+      id
+    }
+  }
+`;


### PR DESCRIPTION
# Description
Cuando vas a la vista de un post puedes iniciar o cancelar un trabajo solo si es que este está con estado "open". Por ahora, la versión es super básica e incompetente, hay que recargar la página para ver el resultado. Se espera hacer mejoras tanto a esta funcionalidad como a otras que tienen este mismo comportamiento en la aplicación, una vez terminadas las features faltantes. 

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature HTML / CSS (please include before/after screenshot)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
# How Has This Been Tested?
Please describe the tests that you ran to verify your changes (Like web browser's or mobile devices). Provide instructions so we can reproduce.
- [ ] Chrome Desktop
- [ ] Safari Desktop
- [ ] Chrome Mobile (not desktop emulator)
- [ ] iOS Mobile (not desktop emulator)
# Screenshots (Only if need)
#### Before this PR
#### After this PR
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] The target of this commit is 'dev'
