### PR TITLE
:sparkles: feat: add link to users name in posts

### DIFF
--- a/src/components/post/show.js
+++ b/src/components/post/show.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import { Row, Col, Image, Form, Button, Alert } from "react-bootstrap";
 import PropTypes from "prop-types";
 import { useQuery, useMutation } from "@apollo/client";
@@ -259,7 +260,7 @@ export default function PostShowComponent(props) {
                 <Form.Check
                   key={index}
                   type="checkbox"
-                  label={employee.name}
+                  label={<Link to={`/users/${employee.id}`}>{employee.name}</Link>}
                   checked={fired.includes(employee.id)}
                   onChange={(event) => handleWorker(event, employee.id)}
                 />
@@ -282,7 +283,7 @@ export default function PostShowComponent(props) {
               <Form.Check
                 key={index}
                 type="checkbox"
-                label={applicant.name}
+                label={<Link to={`/users/${applicant.id}`}>{applicant.name}</Link>}
                 checked={selected.includes(applicant.id)}
                 onChange={(event) => handleApplicant(event, applicant.id)}
               />


### PR DESCRIPTION
# Description
Add link to list of posible/accepted employees, so employers can access their profiles quickly

## Type of change
Please delete options that are not relevant.
- [X] New feature HTML / CSS (please include before/after screenshot)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Manually

# Screenshots (Only if need)
#### Before this PR
![image](https://user-images.githubusercontent.com/30667811/85485287-6dcb8e00-b596-11ea-9895-a2abe3aaa8fa.png)

#### After this PR
![Screenshot (441)](https://user-images.githubusercontent.com/30667811/85485257-5b515480-b596-11ea-9a0f-cd972be811fa.png)
![Screenshot (443)](https://user-images.githubusercontent.com/30667811/85485260-5e4c4500-b596-11ea-8f39-9f3df05090d2.png)


# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have unsuscribed from observables in Components when not using the async Pipe
- [ ] My changes generate no new warnings
- [X] The target of this commit is 'dev'
- [ ] Any dependent changes have been merged and published in downstream modules
